### PR TITLE
feat: add semantic-release with conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,6 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: pnpm test
+      - uses: freckle/check-git-clean-action@v1
+        with:
+          hint: "Run pnpm build to update your dist/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - rc/*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cycjimmy/semantic-release-action@v6.0.0
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
+            @semantic-release/exec
+        env:
+          FORCE_COLOR: 1
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cycjimmy/semantic-release-action@v6.0.0
         with:
           extra_plugins: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: cycjimmy/semantic-release-action@v6.0.0
+        # conventional-changelog-conventionalcommits is held at 9.x: v10 requires
+        # conventional-changelog-writer@9, while semantic-release@25 resolves
+        # writer@8 via @semantic-release/release-notes-generator@14. Unpinned, the
+        # release fails with `Missing helper: "..."`.
         with:
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9
             @semantic-release/exec
         env:
           FORCE_COLOR: 1

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,24 @@
+plugins:
+  - - '@semantic-release/commit-analyzer'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/release-notes-generator'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/github'
+    - successCommentCondition: false
+
+  # Update dist, in case Dependabot PRs merged without doing so
+  - - '@semantic-release/exec'
+    - prepareCmd: 'pnpm install && pnpm run build'
+
+  - - '@semantic-release/git'
+    - assets:
+        - 'dist/**'
+        - 'package.json' # commit updated version back to source
+      message: 'chore(release): update dist and package.json'
+
+  - '@semantic-release/npm'
+
+branches:
+  - main
+  - name: rc/*
+    prerelease: '${name.replace(/^rc\//, "rc-")}'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -10,12 +10,6 @@ plugins:
   - - '@semantic-release/exec'
     - prepareCmd: 'pnpm install && pnpm run build'
 
-  - - '@semantic-release/git'
-    - assets:
-        - 'dist/**'
-        - 'package.json' # commit updated version back to source
-      message: 'chore(release): update dist and package.json'
-
   - '@semantic-release/npm'
 
 branches:

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@ yarn add @freckle/resource-status
 
 ## Release
 
-To trigger a release in this project, merge a commit to `main` prefixed with:
-
-1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
-
-See [RELEASE.md](./RELEASE.md) for more details.
+See [RELEASE.md](./RELEASE.md).
 
 ## `ResourceStatusT<R>`
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Defines the `ResourceStatusT` type and utilities operating on this type.
 yarn add @freckle/resource-status
 ```
 
-## Versioning and release process
+## Release
 
-See [RELEASE.md](./RELEASE.md).
+To trigger a release in this project, merge a commit to `main` prefixed with:
+
+1. `fix:` to trigger a patch release,
+1. `feat:` to trigger minor, or
+1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+
+See [RELEASE.md](./RELEASE.md) for more details.
 
 ## `ResourceStatusT<R>`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,34 +1,14 @@
-# Releases
+# Release
 
-## Versioning
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release)
+with [conventional commits](https://www.conventionalcommits.org/) to trigger releases.
 
-Versioned tags will exist, such as `v1.0.0` and `v2.1.1`. Branches will exist
-for each major version, such as `v1` or `v2` and contain the newest version in
-that series.
+To trigger a release in this project, merge a commit to `main` prefixed with:
 
-## Release process
+1. `fix:` to trigger a patch release,
+1. `feat:` to trigger minor, or
+1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
 
-Given a latest version of v1.0.1,
+Pre-releases can be made by pushing to an `rc/*` branch.
 
-Is this a new major version?
-
-If yes,
-
-```console
-git checkout main
-git pull
-git checkout -b v2
-git tag -s -m v2.0.0 v2.0.0
-git push --follow-tags
-```
-
-Otherwise,
-
-```console
-git checkout main
-git pull
-git checkout v1
-git merge --ff-only -
-git tag -s -m v1.0.2 v1.0.2    # or v1.1.0
-git push --follow-tags
-```
+For more details, see the [Semantic Release](https://illuminate.atlassian.net/wiki/spaces/PENG/pages/17952735277/Semantic+Release) documentation.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ with [conventional commits](https://www.conventionalcommits.org/) to trigger rel
 To trigger a release in this project, merge a commit to `main` prefixed with:
 
 1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+2. `feat:` to trigger minor, or
+3. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
 
 Pre-releases can be made by pushing to an `rc/*` branch.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,4 +11,8 @@ To trigger a release in this project, merge a commit to `main` prefixed with:
 
 Pre-releases can be made by pushing to an `rc/*` branch.
 
+The release does not commit anything back to `main`. `dist/` is tracked, and CI
+checks on every pull request that the committed copy matches a fresh build, so
+`main` is already correct by the time a release runs.
+
 For more details, see the [Semantic Release](https://illuminate.atlassian.net/wiki/spaces/PENG/pages/17952735277/Semantic+Release) documentation.


### PR DESCRIPTION
Adds semantic-release to this repo, following what the other npm packages ended up with rather than the config they started from.

- `.releaserc.yaml` with the `conventionalcommits` preset, GitHub release, and npm publish
- `.github/workflows/release.yml` using `cycjimmy/semantic-release-action@v6.0.0`
- `rc/*` branches produce pre-releases
- `ci.yml` adds [freckle/check-git-clean-action](https://github.com/freckle/check-git-clean-action)`@v1` after `pnpm build`
- `RELEASE.md` and `README.md` replace the manual tag process with conventional-commit instructions

## Changed since the first draft: no commit back to `main`

The original config included `@semantic-release/git`, committing `dist/` and `package.json` back to `main`. That would not have worked here. Ruleset `12304796` on `main` is active, requires a pull request and the `build` check, and lists Renovate as its only bypass actor, while the release job authenticates as `${{ github.token }}`. The push fails with `GH013`.

It would have failed silently first. `@semantic-release/git` was listed before `@semantic-release/npm`, so it runs before the version bump, finds nothing to commit, and skips the push. `maybe-js` had that config until #154 reordered the plugins, which turned the no-op into a hard failure on every release since. `ajax-js`, `query-params-js`, `non-empty-js`, `i18n-scripts-js` and `npm-package-template` are all being changed the same way (freckle/ajax-js#200 and siblings).

npm packages do not need the commit back: `@semantic-release/npm` writes the version into the working-tree `package.json` and publishes from there. `@semantic-release/exec`'s `prepareCmd` still runs `pnpm install && pnpm run build`, so the published tarball contains a fresh build.

The consequence is that `main`'s `package.json` version will trail the published version. That is what the other packages do, and `@freckle/cancelable-promise` has run that way for months.

## What protects `dist/` instead

`dist/` is tracked here and not gitignored, so freshness moves to PR time. The action uses `git status --porcelain`, which catches modified, deleted, mode-changed, type-changed and untracked files. A `git diff`-based check misses untracked files, so a build emitting a new artifact would pass it.

## Also: the preset is pinned to 9.x

`conventional-changelog-conventionalcommits` v10 (2026-06-26) requires `conventional-changelog-writer@9`, but `semantic-release@25` pulls `@semantic-release/release-notes-generator@14`, which depends on `writer@^8.0.0`. An unpinned install gets the 10.4.0 preset against writer 8 and the release fails:

```
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ... Your changelog tooling loaded an
older writer which cannot render ...
```

That is not hypothetical: `non-empty-js` (run 33073073867, today) and `i18n-scripts-js` (08-20, 08-23, 08-26) are failing every release with this error right now. `maybe-js`, `ajax-js`, `npm-package-template` and `typescript-action-template` already pin it. Pinning here means the first release works rather than failing after merge.

`actions/checkout` in `release.yml` moved from v6 to v7, matching `ci.yml`.

Rebased onto `main`, which had advanced by 10+ Renovate commits including pnpm 11.24.0.

## Prerequisites

- [ ] `NPM_TOKEN` available to this repo for npm publishing. `ajax-js` failed three release runs on `Invalid npm token` in April and May, so this is worth confirming before merge rather than after. It is an org secret; org secrets can be scoped to selected repositories.

No ruleset bypass is needed. Nothing in this configuration pushes to `main`.

## Verification

- `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm test` under pnpm 11.24.0 on the rebased branch: 18/18 tests pass and `git status --porcelain` is empty, so the committed `dist/` already matches a fresh build and the new check passes.
- `.releaserc.yaml` and both workflows parse.
- The action was verified on freckle/ajax-js#200, where it resolved `@v1` to `0141bda`, received the hint, ran, and logged `Working tree is clean.`
- Not verified until merge: that a `feat:` commit triggers a release, and the `rc/*` pre-release flow.
